### PR TITLE
Fixed and cleaned up

### DIFF
--- a/backup_rotation.sh
+++ b/backup_rotation.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#@author @Todi Adiyatmo Wijoyo based on 
+#@author @Todi Adiyatmo Wijoyo based on
 #@fork from @Julius Zaromskis(http://nicaw.wordpress.com/2013/04/18/bash-backup-rotation-script/)
 #@description Backup script for your website
 
 # --------------------------
-# Edit this configuration !! 
+# Edit this configuration !!
 # THESE WILL BE THE SETTINGS
 # IF YOU DO NOT SPECIFY THEM
 # WITH SWITCHES.
@@ -14,26 +14,26 @@
 # Backup Destination option, please read the README to find the possible value
 # --------------------
 
-# A Temporary Location to work with files , DO NOT END THE DIRECTORY WITH BACKSLASH ! 
+# A Temporary Location to work with files , DO NOT END THE DIRECTORY WITH BACKSLASH !
 TMP_DIR=/tmp
 
-# The directory to be backed up , DO NOT END THE DIRECTORY WITH BACKSLASH ! 
-BACKUP_DIR=/target_directory
+# The directory to be backed up , DO NOT END THE DIRECTORY WITH BACKSLASH !
+SOURCE_DIR=/home
 
-# The directory where the backups are sent , DO NOT END THE DIRECTORY WITH BACKSLASH ! 
-TARGET_DIR=/the_folder_where_the_backup_are_sent
+# The directory where the backups are sent , DO NOT END THE DIRECTORY WITH BACKSLASH !
+TARGET_DIR=/backups/home
 
 # Hostname
-HOST="yourhost.com"
+HOST="dcim"
 
 # Admin email
-MAIL="admin@yourhost.com"
+MAIL="zack.coffey@dothill.com"
 
 # Email Tag
-EMAIL_SUBJECT_TAG="[backup script@$HOST]"
+EMAIL_SUBJECT_TAG="[backup of $SOURCE_DIR@$HOST]"
 
 # Number of day the daily backup keep ( 2 day = 2 daily backup retention)
-RETENTION_DAY=2
+RETENTION_DAY=5
 
 # Number of day the weekly backup keep (14 day = 2 weekly backup retention )
 RETENTION_WEEK=14
@@ -41,10 +41,10 @@ RETENTION_WEEK=14
 # Number of day the monthly backup keep (30 day = 2 montly backup retention)
 RETENTION_MONTH=60
 
-#Monthly date backup option (day of month)
+# Monthly date backup option (day of month)
 MONTHLY_BACKUP_DATE=1
 
-#Weekly day to backup option (day of week - 1 is monday )
+# Weekly day to backup option (day of week - 1 is monday )
 WEEKLY_BACKUP_DAY=6
 
 # -----------------
@@ -52,19 +52,19 @@ WEEKLY_BACKUP_DAY=6
 # Enter all data within the ' ' single quote !
 # -----------------
 
-#This is the FTP servers host or IP address. 
-FTP_HOST='ftp.yourhost.com' 
+#This is the FTP servers host or IP address.
+FTP_HOST='ftp.yourhost.com'
 
 #FTP PORT
 FTP_PORT=21
 
-#This is the FTP user that has access to the server. 
-FTP_USER='user'           
+#This is the FTP user that has access to the server.
+FTP_USER='user'
 
-#This is the password for the FTP user. 
-FTP_PASSWORD='password'          
+#This is the password for the FTP user.
+FTP_PASSWORD='password'
 
-#The backup directory on remote machine, DO NOT END THE DIRECTORY WITH BACKSLASH ! 
+#The backup directory on remote machine, DO NOT END THE DIRECTORY WITH BACKSLASH !
 FTP_TARGET_DIR='ftp_target_dir'
 
 # --------------------------------------------------
@@ -72,9 +72,9 @@ FTP_TARGET_DIR='ftp_target_dir'
 # Enter all data within the ' ' single quote !
 # --------------------------------------------------
 
-DB_USER='user'
-DB_PASSWORD='password'
-DB_DATABASE='database'
+DB_USER='dcim'
+DB_PASSWORD='dcim'
+DB_DATABASE='dcim'
 DB_HOST='127.0.0.1'
 
 # -------------------------------------------------
@@ -96,9 +96,9 @@ FTP_BACKUP_OPTION=0
 
 #--------------------------------------
 # You may set when you want to schedule
-# a backup of the SQL databases or the 
-# physical files by setting the number 
-# between 1-7. The chart below will 
+# a backup of the SQL databases or the
+# physical files by setting the number
+# between 1-7. The chart below will
 # help you know which to pick.
 #----------------------------------#
 # Daily | Weekly | Monthly | Value #
@@ -113,8 +113,8 @@ FTP_BACKUP_OPTION=0
 #----------------------------------#
 
 #Between 1-7
-SQL_BACKUP_OPTION=1
-FILES_BACKUP_OPTION=0
+SQL_BACKUP_OPTION=0
+FILES_BACKUP_OPTION=7
 
 # -----------------
 # End configuration
@@ -175,19 +175,19 @@ do
       ;;
 
     --now)
-      RUN_NOW=1      
+      RUN_NOW=1
       ;;
 
     -bd|--backupdir)
       if [[ "$#" -gt 1 && ! "$2" = \-* ]]; then
         FILES_BACKUP_OPTION=$2
         if [[ ! "$3" = \-* && ! "$3" == "" ]]; then
-          BACKUP_DIR=${3%/}
+          SOURCE_DIR=${3%/}
           shift 2
         else
           echo "Error in -bd|--backupdir syntax. Script failed."
           exit 1
-        fi  
+        fi
       fi
       ;;
 
@@ -196,7 +196,7 @@ do
       if [[ "$#" -gt 1 && ! "$2" = \-* ]]; then
        TARGET_DIR=${2%/}
        LOCAL_BACKUP_OPTION=1
-       shift 
+       shift
       else
         echo "Error in -td|--targetdir syntax. Script failed."
         exit 1
@@ -210,7 +210,7 @@ do
       else
         echo "Error in -e|--email syntax. Script failed."
         exit 1
-      fi  
+      fi
       ;;
 
     -r|--retention)
@@ -222,7 +222,7 @@ do
       else
         echo "Error in -r|--retention syntax. Script failed."
         exit 1
-      fi  
+      fi
       ;;
 
     -d|--dates)
@@ -233,7 +233,7 @@ do
       else
         echo "Error in -d|--dates syntax. Script failed."
         exit 1
-      fi  
+      fi
       ;;
 
     --)              # End of all options.
@@ -249,7 +249,7 @@ do
         break
         ;;
 
-    *)  # Anything unrecognized     
+    *)  # Anything unrecognized
         echo "The value "$1" was not expected. Script failed."
         exit 1
         ;;
@@ -270,7 +270,7 @@ week_day=`date +"%u"`
   if [ "$month_day" -eq $MONTHLY_BACKUP_DATE ] ; then
     BACKUP_TYPE='-monthly'
     RETENTION_DAY_LOOKUP=$RETENTION_MONTH
-    
+
     COMPARATOR=4
   else
   # On saturdays do
@@ -291,15 +291,20 @@ week_day=`date +"%u"`
 
 CURRENT_DIR=${PWD}
 
-#create cache to delete
-mkdir $TMP_DIR/.ftp_cache/ 
-cd $TMP_DIR/.ftp_cache/ 
-find -maxdepth 1 -name "*$BACKUP_TYPE*" -mtime +$RETENTION_DAY_LOOKUP >>  $TMP_DIR/.ftp_cache/search_file.tmp
-cd $CURRENT_DIR
+if [ ! $FTP_BACKUP_OPTION -eq 0 ]; then
+  # Create list of expired backups
+  mkdir -p $TMP_DIR/.ftp_cache/
+  cd $TMP_DIR/.ftp_cache/
+  find -maxdepth 1 -name "*$BACKUP_TYPE*" -mtime +$RETENTION_DAY_LOOKUP >>  $TMP_DIR/.ftp_cache/search_file.tmp
+  cd $CURRENT_DIR
+  # List has been created, now lets get rid of them locally.
+  # Delete expired backups
+  find $TMP_DIR/.ftp_cache/ -maxdepth 1 -mtime +$RETENTION_DAY_LOOKUP -name "*$BACKUP_TYPE*" -exec rm -rv {} \;
+fi
 
-#delete old files
-find $TMP_DIR/ -maxdepth 1 -mtime +$RETENTION_DAY_LOOKUP -name "*$BACKUP_TYPE*" -exec rm -rv {} \;
-find $TMP_DIR/.ftp_cache/ -maxdepth 1 -mtime +$RETENTION_DAY_LOOKUP -name "*$BACKUP_TYPE*" -exec rm -rv {} \;
+# Cleanup expired backups
+echo "Removing expired backups..."
+find $TARGET_DIR/ -maxdepth 1 -mtime +$RETENTION_DAY_LOOKUP -name "*$BACKUP_TYPE*" -exec rm -rv {} \;
 
 PERFORM_SQL_BACKUP=0
 PERFORM_FILES_BACKUP=0
@@ -309,11 +314,11 @@ PERFORM_FILES_BACKUP=0
 # but rather if the backup of the
 # files should be SQL or FILES.
 if [[ $(( $COMPARATOR & $SQL_BACKUP_OPTION )) == $COMPARATOR ]]; then
-  PERFORM_SQL_BACKUP=1 
+  PERFORM_SQL_BACKUP=1
 fi
 
 if [[ $(( $COMPARATOR & $FILES_BACKUP_OPTION )) == $COMPARATOR ]]; then
-  PERFORM_FILES_BACKUP=1 
+  PERFORM_FILES_BACKUP=1
 fi
 
 #This will force the backup to run immediately.
@@ -326,21 +331,24 @@ fi
 
 echo "Creating backup dir.."
 
-#Remove previous backup
+#Remove previous tmp dir
 rm -rf $TMP_DIR/backup.incoming
-mkdir $TMP_DIR/backup.incoming
+mkdir -p $TMP_DIR/backup.incoming
 
-cd $TMP_DIR/backup.incoming
+# + I don't think we need to cd into there since it's specified via the command
+#cd $TMP_DIR/backup.incoming
+
 # Destination file names
 base_backup_filename=`date +"%d-%m-%Y"`$BACKUP_TYPE
-backup_filename=$base_backup_filename'.tar.gz'
+backup_filename=$base_backup_filename'.tar.xz'
 
+# SQL section
 if [ ! $PERFORM_SQL_BACKUP -eq 0 ]; then
 
   echo "Perform sql backup..."
 
   # Destination file names
-  backup_filename=$base_backup_filename'.sql.tar.bz2'
+  backup_filename=$base_backup_filename'.sql.tar.xz'
 
   # Dump MySQL tables
   mysqldump -h $DB_HOST -u $DB_USER -p$DB_PASSWORD $DB_DATABASE $EXTRA_MYSQLDUMP_OPTIONS > $TMP_DIR/backup.incoming/mysql_dump.sql
@@ -348,7 +356,7 @@ if [ ! $PERFORM_SQL_BACKUP -eq 0 ]; then
   echo "Compress sql backup.."
 
   cd $TMP_DIR/backup.incoming
-  tar -cjf $backup_filename mysql_dump.sql
+  tar -cJf $backup_filename mysql_dump.sql
 
 
   #clean sql file
@@ -357,18 +365,21 @@ fi
 
 cd $CURRENT_DIR
 
+# + This doesn't seem to work right. Maybe it's in the wrong place or looking for the wrong thing.
+# Even if backup works properly, this still generates an email saying that it failed.
+#
 # Optional check if source files exist. Email if failed.
-if [ ! -f $TMP_DIR/backup.incoming/$backup_filename ]; then
-  echo "Daily backup failed! Please check for missing files." | mail -s "$EMAIL_SUBJECT_TAG Backup Failed" $MAIL
-fi
+#if [ ! -f $TMP_DIR/backup.incoming/$backup_filename ]; then
+#  echo "Daily backup failed! Please check for missing files." | mail -s "$EMAIL_SUBJECT_TAG Backup Failed" $MAIL
+#fi
 
-#Preform Files Backup
+# Perform Files Backup
 if [ ! $PERFORM_FILES_BACKUP -eq 0 ]; then
-  backup_filename=$base_backup_filename'.data.tar.bz2'
+  backup_filename=$base_backup_filename'.data.tar.xz'
   echo "Perform file backup"
   # Compress files
   cd $TARGET_DIR
-  tar -cjf $TMP_DIR/backup.incoming/$backup_filename $BACKUP_DIR
+  tar -chJf $TMP_DIR/backup.incoming/$backup_filename $SOURCE_DIR
 fi
 
 # FTP
@@ -376,8 +387,8 @@ if [ ! $FTP_BACKUP_OPTION -eq 0 ]; then
   echo "Copy backup to FTP.."
   #create cache copy to detect the remote file
   #remove previous backup
-  mkdir $TMP_DIR/.ftp_cache
-  touch $TMP_DIR/.ftp_cache/$backup_filename 
+  mkdir -p $TMP_DIR/.ftp_cache
+  touch $TMP_DIR/.ftp_cache/$backup_filename
 
   echo "user $FTP_USER $FTP_PASSWORD" >> $TMP_DIR/backup.incoming/ftp_command.tmp
   echo "mkdir $FTP_TARGET_DIR" >> $TMP_DIR/backup.incoming/ftp_command.tmp
@@ -388,11 +399,10 @@ if [ ! $FTP_BACKUP_OPTION -eq 0 ]; then
   do
    echo "delete ${f/.\//}" >>  $TMP_DIR/backup.incoming/ftp_command.tmp
   done
-  echo "bye" >>  $TMP_DIR/backup.incoming/ftp_command.tmp 
+  echo "bye" >>  $TMP_DIR/backup.incoming/ftp_command.tmp
 
   ftp -n -v $FTP_HOST $FTP_PORT < $TMP_DIR/backup.incoming/ftp_command.tmp
 
-  
   echo "FTP Backup finish" | mail -s "$EMAIL_SUBJECT_TAG FTP backup finished !" $MAIL
 fi
 
@@ -412,13 +422,23 @@ if [ ! $LOCAL_BACKUP_OPTION -eq 0 ]; then
   mv -v $TMP_DIR/backup.incoming/* $TARGET_DIR
 fi
 
-# Remove previous backup
-rm -rf $TMP_DIR/backup.incoming
-
 # Optional check if source files exist. Email if failed.
 if [ -f $TARGET_DIR/$backup_filename ]; then
+  # +Randomly generate a number to reduse the chances of overwriting an existing file. Helps ensure we get a current list and not something possibly stale.
+  RANDOM=$(( ( RANDOM % 100 )  + 1 ))
+  # +Temp file to allow easy emailing of current list of backups.
+  BACKUP_LIST=$TMP_DIR/backup.list.$RANDOM.txt
+  touch $BACKUP_LIST
   echo "Sending mail"
-  echo "Local backup finish" | mail -s "$EMAIL_SUBJECT_TAG Finished !" $MAIL
+  echo "Local backup finished. Here's the current list of backups." > $BACKUP_LIST
+  echo " " >> $BACKUP_LIST
+  # +Sleep here to give the system a chance to catch up. If it goes to fast, the total size count could sometimes be incorrect.
+  sleep 2
+  ls -lah $TARGET_DIR >> $BACKUP_LIST
+  cat $BACKUP_LIST | mail -s "$EMAIL_SUBJECT_TAG Finished !" $MAIL
+  rm $TMP_DIR/backup.list.*
+else
+  echo "$TARGET_DIR/$backup_filename does not seem to exist. Something failed." | mail -s "$EMAIL_SUBJECT_TAG Finished, but failed." $MAIL
 fi
 
 echo "Finish.."


### PR DESCRIPTION
Clarified better between what is being backed up and where it's going. (Source and Target)
Fixed cleaning expired backups. Looks in $TARGET_DIR and not in $TMP_DIR. 
Added if check for only creating .ftp_cache/search_file.tmp and deleting expired backups, if $FTP_BACKUP_OPTION=1
Removed a cd $TMP_DIR/backup.incoming. Doesn't appear to be needed.
Fixed "Optional check if source files exist. Email if failed." Previously would email a failure even if everything was fine.
Changed tar and variables to use xz instead. I get a bit better compression with xz instead.
Note, I don't currently have a FTP server to test with. But it looks like .ftp_cache will be a local copy of what's on the FTP site anyway. This could consume a lot of disk space.
Changed mkdir to include -p so if a directory already exists it doesn't throw an error.
Removed extra "rm -rf $TMP_DIR/backup.incoming"
Updated email subject to include source dir.
Changed tar to follow symlinks.
... Probably some more changes that I forgot to mention. FTP is untested. Expired backup deleting is untested.
